### PR TITLE
Replace bevy_enhanced_input with custom impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,32 +599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_enhanced_input"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73a9e5981b0b94b453a7b5ecdcb1f061da8dc8a9732683f5c55a9d887126d74"
-dependencies = [
- "bevy",
- "bevy_enhanced_input_macros",
- "bitflags 2.9.0",
- "log",
- "serde",
- "variadics_please",
-]
-
-[[package]]
-name = "bevy_enhanced_input_macros"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f50d91e55d560d1341b6592f80434889b8002a765121f60b44084ca041af8a"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bevy_enoki"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,41 +1777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,12 +2003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,7 +2107,6 @@ version = "0.1.0"
 dependencies = [
  "avian2d",
  "bevy",
- "bevy_enhanced_input",
  "bevy_enoki",
  "rand",
  "thiserror 2.0.12",
@@ -2408,12 +2340,6 @@ name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
@@ -3973,12 +3899,6 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ bevy = { version = "0.16", default-features = false, features = [
     "wayland",
     "webgl2",
 ] }
-bevy_enhanced_input = "0.11.0"
 bevy_enoki = "0.4.0"
 rand = "0.8"
 thiserror = "2.0.12"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,150 @@
+use std::{any::TypeId, marker::PhantomData};
+
+use bevy::{platform::collections::HashMap, prelude::*};
+
+pub fn input_plugin(app: &mut bevy::prelude::App) {
+    app.add_systems(Update, trigger_actions);
+}
+
+#[derive(Debug, Deref, Event)]
+pub struct Started<T>(PhantomData<fn(T)>);
+
+#[derive(Debug, Deref, Event)]
+pub struct Running<T>(PhantomData<fn(T)>);
+
+#[derive(Debug, Deref, Event)]
+pub struct Ended<T>(PhantomData<fn(T)>);
+
+#[derive(Debug)]
+struct ActionBinding {
+    triggers: Vec<KeyCode>,
+    trigger_action: fn(&mut Commands, ActionState, Entity),
+}
+
+fn trigger_action<A: 'static>(commands: &mut Commands, state: ActionState, entity: Entity) {
+    let mut entity = commands.entity(entity);
+    match state {
+        ActionState::JustPressed => {
+            entity.trigger(Started::<A>(PhantomData));
+        }
+        ActionState::Pressed => {
+            entity.trigger(Running::<A>(PhantomData));
+        }
+        ActionState::JustReleased => {
+            entity.trigger(Ended::<A>(PhantomData));
+        }
+    }
+}
+
+#[derive(Debug, Default, Component)]
+pub struct ActionMappings {
+    mappings: HashMap<TypeId, ActionBinding>,
+}
+
+impl ActionMappings {
+    pub fn bind<T: std::any::Any>(&mut self, keys: impl IntoIterator<Item = KeyCode>) {
+        let id = std::any::TypeId::of::<T>();
+        self.mappings
+            .entry(id)
+            .or_insert_with(|| ActionBinding {
+                triggers: vec![],
+                trigger_action: trigger_action::<T>,
+            })
+            .triggers
+            .extend(keys);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ActionState {
+    JustPressed,
+    Pressed,
+    JustReleased,
+}
+
+fn trigger_actions(
+    mut commands: Commands,
+    input_events: Res<ButtonInput<KeyCode>>,
+    action_query: Query<(Entity, &ActionMappings)>,
+) {
+    for (entity, mappings) in &action_query {
+        for action in mappings.mappings.values() {
+            let inputs = action.triggers.iter().copied();
+            if input_events.any_just_pressed(inputs.clone()) {
+                (action.trigger_action)(&mut commands, ActionState::JustPressed, entity)
+            } else if input_events.any_pressed(inputs.clone()) {
+                (action.trigger_action)(&mut commands, ActionState::Pressed, entity)
+            } else if input_events.any_just_released(inputs) {
+                (action.trigger_action)(&mut commands, ActionState::JustReleased, entity)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use bevy::prelude::*;
+
+    use crate::input::{Ended, Running};
+
+    use super::{ActionMappings, Started, input_plugin};
+
+    struct Jump;
+
+    #[test]
+    fn check_triggered() {
+        let mut app = App::new();
+        app.add_plugins(input_plugin);
+
+        let mut actions = ActionMappings::default();
+        actions.bind::<Jump>([KeyCode::Space]);
+
+        static IS_JUMPING: AtomicBool = AtomicBool::new(false);
+
+        app.world_mut()
+            .spawn((actions,))
+            .observe(|_trigger: Trigger<Started<Jump>>| {
+                IS_JUMPING.store(true, std::sync::atomic::Ordering::Release);
+            })
+            .observe(|_trigger: Trigger<Running<Jump>>| {
+                IS_JUMPING.store(true, std::sync::atomic::Ordering::Release);
+            })
+            .observe(|_trigger: Trigger<Ended<Jump>>| {
+                IS_JUMPING.store(false, std::sync::atomic::Ordering::Release);
+            });
+
+        let mut input = ButtonInput::<KeyCode>::default();
+        input.press(KeyCode::Space);
+        app.insert_resource(input);
+
+        app.update();
+
+        // verify that we are pressing the button
+        assert!(IS_JUMPING.load(std::sync::atomic::Ordering::Acquire));
+
+        IS_JUMPING.store(false, std::sync::atomic::Ordering::Release);
+
+        {
+            let mut inputs = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            inputs.clear();
+        }
+
+        app.update();
+
+        // verify that we are _STILL_ pressing the button
+        assert!(IS_JUMPING.load(std::sync::atomic::Ordering::Acquire));
+
+        {
+            let mut inputs = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            inputs.clear();
+            inputs.release_all();
+        }
+
+        app.update();
+
+        // verify that we are no longer pressing the button
+        assert!(!IS_JUMPING.load(std::sync::atomic::Ordering::Acquire))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use avian2d::{PhysicsPlugins, prelude::Gravity};
 use bevy::prelude::*;
-use bevy_enhanced_input::EnhancedInputPlugin;
 use bevy_enoki::{EnokiPlugin, Particle2dEffect};
 use level::Level;
 
 mod audio;
 mod game;
 mod hud;
+mod input;
 mod level;
 mod splash;
 mod starfield;
@@ -25,7 +25,7 @@ fn main() {
         }))
         .init_state::<GameState>()
         .enable_state_scoped_entities::<GameState>()
-        .add_plugins((PhysicsPlugins::default(), EnhancedInputPlugin, EnokiPlugin))
+        .add_plugins((PhysicsPlugins::default(), EnokiPlugin))
         .insert_resource(Gravity::ZERO)
         .add_plugins((
             splash::splash_plugin,
@@ -36,6 +36,7 @@ fn main() {
             won::won_plugin,
             audio::audio_plugin,
             starfield::starfield_plugin,
+            input::input_plugin,
         ))
         .run();
 }


### PR DESCRIPTION
This PR removes the `bevy_enhanced_input` dependency and uses a custom solution.

I tried to not overcomplicate it too much. What do you think?

I tried to show the idea of decoupling `input -> action -> observer`.

I will adjust the book as needed once we agree on the implementation.